### PR TITLE
fix GLIBC_2.33' not found to run on ubuntu 20.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   system_test:
     name: Test
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/hidakatsuya/shopping_list/actions/runs/3696163881/jobs/6259492972
```
/bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require': /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/bootsnap.so) - /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/bootsnap.so (LoadError)
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/compile_cache/iseq.rb:3:in `<top (required)>'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/compile_cache.rb:16:in `require_relative'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/compile_cache.rb:16:in `setup'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap.rb:55:in `setup'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap.rb:97:in `default_setup'
	from /bundle/ruby/3.1.0/gems/bootsnap-1.14.0/lib/bootsnap/setup.rb:5:in `<top (required)>'
	from /app/config/boot.rb:6:in `require'
	from /app/config/boot.rb:6:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'
```

bundle install する環境（ubuntu-latest）の glibc と、インストールした gem を使う環境（debian11）で glibc のバージョンが異なることが原因。

- ubuntu-latest (22.04): glibc 2.33
- debian11 (rails-dev container): glibc 2.31

2022/10 - 11 で ubuntu-latest が 20.04 -> 22.04 へ変更されたことによって失敗するようになった。
https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

ひとまず、ubuntu 20.04 を使う。