### PR TITLE
Run test on ubuntu-latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   system_test:
     name: Test
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -27,16 +27,10 @@ jobs:
         restore-keys: |
           ${{ env.RUBY_VERSION }}-gems-
 
-    - name: Bundle
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        bundle config path $BUNDLE_STORE_PATH
-        bundle install --jobs 4 --retry 3
-
     - name: Build and setup
       run: |
         docker-compose pull app chrome postgres
-        docker-compose run app bin/rails db:prepare
+        docker-compose run app bin/setup
         docker-compose up -d app chrome
 
     - name: Test


### PR DESCRIPTION
https://github.com/hidakatsuya/shopping_list/pull/62 で bundle install する環境（ubuntu-latest）の glibc と、インストールした gem を使う環境（debian11）で glibc のバージョンが異なることで CI が失敗するようになった。ひとまず、 ubuntu 20.04 を使って回避していた。

そもそも、container の外側で bundle install する必要がないため、そのステップを削除した。これにより、glibc の差が生じないため ubuntu-latest を使うようにする。